### PR TITLE
Fix error on loading plugin

### DIFF
--- a/rplugin/python/neomake-platformio.py
+++ b/rplugin/python/neomake-platformio.py
@@ -33,7 +33,7 @@ class Main(object):
         ])
         json_lines = []
 
-        for line in lines:
+        for line in lines.decode('UTF-8').splitlines():
             if found_start and brace_count == 0:
                 break
             if not found_start and line.startswith('{'):


### PR DESCRIPTION
I could not use this plugin because on nvim startup there was a stack trace. I found out that in the ```get_idestate``` method, lines is expected to be a list of strings, but it was a binary array with ascii values instead. This one-line change does fix the problem for me, but I do not really know python and do not know if this is the right way to do it. But the plugin now works well.